### PR TITLE
DEV: Fix plugin tests following a core change

### DIFF
--- a/spec/lib/affiliate_processor_spec.rb
+++ b/spec/lib/affiliate_processor_spec.rb
@@ -37,6 +37,7 @@ describe AffiliateProcessor do
     SiteSetting.queue_jobs = false
     SiteSetting.affiliate_amazon_com = 'sams-shop'
 
+    stub_request(:get, "http://www.amazon.com/link?testing").to_return(status: 200, body: "")
     post = create_post(raw: 'this is an www.amazon.com/link?testing yay')
     post.reload
 


### PR DESCRIPTION
There was an `Exception` rescue in core that was hiding an error raised during a spec of this plugin. Core now surfaces exceptions in the test environment which causes the spec to fail now.

Related to https://github.com/discourse/discourse/pull/16150.