### PR TITLE
DEV: Change settings root from plugins: to discourse_affiliate

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,6 @@
+en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_affiliate: "Discourse Affiliate"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_affiliate:
   affiliate_enabled:
     default: true
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.